### PR TITLE
fix: use KMS key ID instead of name

### DIFF
--- a/velero.tf
+++ b/velero.tf
@@ -96,7 +96,7 @@ module "bucket" {
   lifecycle_rules = var.lifecycle_rules
 
   encryption = var.enable_kms ? {
-    default_kms_key_name = google_kms_crypto_key.velero[0].name
+    default_kms_key_name = google_kms_crypto_key.velero[0].id
   } : null
 
   # https://github.com/terraform-google-modules/terraform-google-cloud-storage/issues/142


### PR DESCRIPTION
The name is not unique when using this module across regions in the same project